### PR TITLE
fix work order links referencing invalid doctypes

### DIFF
--- a/car_workshop/car_workshop/doctype/work_order/work_order.json
+++ b/car_workshop/car_workshop/doctype/work_order/work_order.json
@@ -183,16 +183,6 @@
   "index_web_pages_for_search": 1,
   "links": [
     {
-      "group": "Reference",
-      "link_doctype": "Customer",
-      "link_fieldname": "customer"
-    },
-    {
-      "group": "Reference",
-      "link_doctype": "Customer Vehicle",
-      "link_fieldname": "customer_vehicle"
-    },
-    {
       "group": "Transactions",
       "link_doctype": "Workshop Material Issue",
       "link_fieldname": "work_order"


### PR DESCRIPTION
## Summary
- remove Customer and Customer Vehicle link definitions from Work Order DocType

## Testing
- `pytest`
- `python setup.py build` *(fails: ModuleNotFoundError: No module named 'setuptools')*
- `python - <<'PY'
try:
    import frappe
    from frappe.desk.notifications import get_open_count
    result = get_open_count("Work Order", "test@example.com")
    print(result)
except Exception as e:
    print("Error:", e)
PY` *(fails: No module named 'frappe.desk')*


------
https://chatgpt.com/codex/tasks/task_e_68a68442e194833381f22438eff2564b