### PR TITLE
Add job duration field and migration

### DIFF
--- a/car_workshop/car_workshop/doctype/job_type/job_type.json
+++ b/car_workshop/car_workshop/doctype/job_type/job_type.json
@@ -9,6 +9,7 @@
     "job_name",
     "description",
     "default_price",
+    "time_minutes",
     "is_opl",
     "opl_vendor",
     "opl_item_code",
@@ -37,6 +38,12 @@
       "fieldtype": "Currency",
       "label": "Default Price",
       "in_list_view": 1
+    },
+    {
+      "fieldname": "time_minutes",
+      "fieldtype": "Float",
+      "label": "Time (Minutes)",
+      "default": "0"
     },
     {
       "default": "0",

--- a/car_workshop/car_workshop/doctype/service_package/service_package.py
+++ b/car_workshop/car_workshop/doctype/service_package/service_package.py
@@ -27,10 +27,20 @@ class ServicePackage(Document):
         job_durations = {}
 
         if job_types:
+            job_fields = ["name", "default_price"]
+            has_column = getattr(getattr(frappe, "db", None), "has_column", None)
+            if callable(has_column):
+                if frappe.db.has_column("Job Type", "time_minutes"):
+                    job_fields.append("time_minutes")
+                else:
+                    job_fields.append("0 as time_minutes")
+            else:
+                job_fields.append("time_minutes")
+
             job_data = frappe.get_all(
                 "Job Type",
                 filters={"name": ["in", job_types]},
-                fields=["name", "default_price", "time_minutes"],
+                fields=job_fields,
             )
 
             missing_rate = []

--- a/car_workshop/patches.txt
+++ b/car_workshop/patches.txt
@@ -1,3 +1,4 @@
 # Patches file - disimpan di car_workshop/patches.txt
 car_workshop.patches.replace_null_purchase_order
 car_workshop.patches.add_billing_preference
+car_workshop.patches.add_time_minutes_to_job_type

--- a/car_workshop/patches/add_time_minutes_to_job_type.py
+++ b/car_workshop/patches/add_time_minutes_to_job_type.py
@@ -1,0 +1,8 @@
+import frappe
+
+
+def execute():
+    """Add time_minutes column to Job Type and backfill existing records"""
+    frappe.reload_doc("car_workshop", "doctype", "job_type")
+    frappe.db.sql("""update `tabJob Type` set time_minutes = 0 where time_minutes is null""")
+


### PR DESCRIPTION
## Summary
- add `time_minutes` field to Job Type to track job duration
- reload Job Type via patch and backfill existing rows
- guard `ServicePackage.calculate_totals` against missing `time_minutes`

## Testing
- `python - <<'PY'
import sys, types

class Document:
    def __init__(self, **kwargs):
        for key, value in kwargs.items():
            setattr(self, key, value)

a = types.SimpleNamespace(Document=Document)
frappe_model = types.SimpleNamespace(document=a)

class DB:
    def has_column(self, doctype, column):
        return True

def get_all(doctype, filters=None, fields=None, **kwargs):
    if doctype == 'Job Type':
        return [types.SimpleNamespace(name='Oil Change', default_price=100, time_minutes=30)]
    if doctype == 'Job Type Item':
        return []
    if doctype == 'Part':
        return []
    return []

frappe_stub = types.SimpleNamespace(
    db=DB(),
    get_all=get_all,
    throw=lambda msg: (_ for _ in ()).throw(Exception(msg)),
)

sys.modules['frappe'] = frappe_stub
sys.modules['frappe.model'] = frappe_model
sys.modules['frappe.model.document'] = a

from car_workshop.car_workshop.doctype.service_package.service_package import ServicePackage

sp = ServicePackage(details=[types.SimpleNamespace(item_type='Job', job_type='Oil Change', quantity=1, amount=0, rate=0)], price_list=None)
sp.validate()
print('price', sp.price, 'time', sp.total_time_minutes)
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a694dc9f5c83338ce79ad9d800915e