### PR TITLE
Rename OPL fields and enforce vendor/item code validation

### DIFF
--- a/car_workshop/car_workshop/doctype/job_type/job_type.py
+++ b/car_workshop/car_workshop/doctype/job_type/job_type.py
@@ -6,18 +6,18 @@ class JobType(Document):
     def validate(self):
         self.validate_opl_logic()
         self.calculate_item_amounts()
-    
+
     def validate_opl_logic(self):
         """Validate OPL (Outsourced) job logic"""
         if self.is_opl:
             # Validations for OPL jobs
-            if not self.opl_supplier:
-                frappe.throw(_("OPL Supplier is required for outsourced jobs"))
-            if not self.opl_item:
-                frappe.throw(_("OPL Item is required for outsourced jobs"))
+            if not self.opl_vendor:
+                frappe.throw(_("OPL Vendor is required for outsourced jobs"))
+            if not self.opl_item_code:
+                frappe.throw(_("OPL Item Code is required for outsourced jobs"))
             if self.items and len(self.items) > 0:
-                frappe.throw(_("Job Type Items should not be added for OPL jobs - use only OPL Item"))
-            
+                frappe.throw(_("Job Type Items should not be added for OPL jobs - use only OPL Item Code"))
+
             # Set default price based on OPL item if not already set
             if not self.default_price:
                 opl_cost = self.get_opl_cost()
@@ -30,19 +30,19 @@ class JobType(Document):
     
     def get_opl_cost(self):
         """Get the cost from the linked OPL item"""
-        if not self.opl_item:
+        if not self.opl_item_code:
             return 0
             
         try:
             # Try to get standard_rate from the item
-            item_rate = frappe.db.get_value("Item", self.opl_item, "standard_rate")
+            item_rate = frappe.db.get_value("Item", self.opl_item_code, "standard_rate")
             
             # If standard_rate is not set, try to get price from Item Price
             if not item_rate:
                 item_prices = frappe.get_all(
                     "Item Price",
                     filters={
-                        "item_code": self.opl_item,
+                        "item_code": self.opl_item_code,
                         "selling": 1
                     },
                     fields=["price_list_rate"],

--- a/tests/test_job_type_validation.py
+++ b/tests/test_job_type_validation.py
@@ -1,0 +1,42 @@
+import sys
+import types
+from pathlib import Path
+import pytest
+
+class Document:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def get(self, name):
+        return getattr(self, name, None)
+
+frappe_stub = types.SimpleNamespace(
+    _=lambda m: m,
+    throw=lambda msg: (_ for _ in ()).throw(Exception(msg)),
+    db=types.SimpleNamespace(get_value=lambda *a, **k: 0),
+    get_all=lambda *a, **k: [],
+    log_error=lambda *a, **k: None,
+)
+
+sys.modules['frappe'] = frappe_stub
+sys.modules['frappe.model'] = types.SimpleNamespace(document=types.SimpleNamespace(Document=Document))
+sys.modules['frappe.model.document'] = types.SimpleNamespace(Document=Document)
+
+# Ensure package root is on the path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from car_workshop.car_workshop.doctype.job_type.job_type import JobType
+
+
+def test_opl_requires_vendor_and_item_code():
+    jt = JobType(is_opl=1, items=[], default_price=None)
+    with pytest.raises(Exception):
+        jt.validate()
+
+    jt = JobType(is_opl=1, opl_vendor='SUP-001', items=[], default_price=None)
+    with pytest.raises(Exception):
+        jt.validate()
+
+    jt = JobType(is_opl=1, opl_vendor='SUP-001', opl_item_code='ITEM-001', items=[], default_price=None)
+    jt.validate()


### PR DESCRIPTION
## Summary
- align Job Type Python logic with new `opl_vendor` and `opl_item_code` fields
- ensure outsourced jobs require vendor and item code
- add tests verifying OPL fields validation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a694de57a88333913ead92a4d0d4a4