### PR TITLE
fix: populate rate from item code

### DIFF
--- a/car_workshop/car_workshop/doctype/job_type/job_type.js
+++ b/car_workshop/car_workshop/doctype/job_type/job_type.js
@@ -118,15 +118,15 @@ frappe.ui.form.on('Job Type Item', {
         update_item_amount(frm, cdt, cdn);
     },
     
-    item: function(frm, cdt, cdn) {
+    item_code: function(frm, cdt, cdn) {
         // When item is selected, fetch its price
         var row = locals[cdt][cdn];
-        if (row.item) {
+        if (row.item_code) {
             frappe.call({
                 method: 'frappe.client.get_value',
                 args: {
                     doctype: 'Item',
-                    filters: { name: row.item },
+                    filters: { name: row.item_code },
                     fieldname: ['standard_rate']
                 },
                 callback: function(r) {


### PR DESCRIPTION
## Summary
- rename Job Type Item handler from item to item_code
- read standard_rate when selecting item and update rate field accordingly

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a6a5c36d708333b9a397e9227fa684