### PR TITLE
Use json.dumps for service package details hash

### DIFF
--- a/car_workshop/car_workshop/doctype/service_package/service_package.py
+++ b/car_workshop/car_workshop/doctype/service_package/service_package.py
@@ -2,6 +2,7 @@ import frappe
 from frappe.model.document import Document
 from collections import defaultdict
 import hashlib
+import json
 
 class ServicePackage(Document):
     def validate(self):
@@ -167,10 +168,10 @@ class ServicePackage(Document):
         previous_details = serialize(previous_doc.get("details"))
 
         current_hash = hashlib.md5(
-            frappe.as_json(current_details, sort_keys=True).encode()
+            json.dumps(current_details, sort_keys=True).encode()
         ).hexdigest()
         previous_hash = hashlib.md5(
-            frappe.as_json(previous_details, sort_keys=True).encode()
+            json.dumps(previous_details, sort_keys=True).encode()
         ).hexdigest()
 
         return current_hash != previous_hash


### PR DESCRIPTION
## Summary
- Replace `frappe.as_json` with `json.dumps` when hashing Service Package details to avoid serialization errors
- Import `json` in Service Package doctype

## Testing
- `pytest tests/test_service_package.py -q`
- `pytest -q`
- `python - <<'PY'
import types, sys
from tests import test_service_package as tsp

# Using same stub environment from tests
document = tsp.ServicePackage(
    price_list='Retail',
    details=[types.SimpleNamespace(item_type='Job', job_type='OPL Job', quantity=1, rate=0, amount=0, remarks='note', creation=object(), modified=object())]
)
# Provide previous doc with identical details to test _details_have_changed
prev_detail = types.SimpleNamespace(item_type='Job', job_type='OPL Job', quantity=1, rate=0, amount=0, remarks='note', creation=object(), modified=object())
previous_doc = tsp.ServicePackage(price_list='Retail', details=[prev_detail])

document.get_doc_before_save = lambda: previous_doc

document.has_value_changed = lambda field: True

try:
    document.before_save()
    print('saved successfully')
except Exception as e:
    print('error:', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a6bbfbe9e88333be3e28d0c702aa79